### PR TITLE
add addresses to the response of user and users queries

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -17,10 +17,12 @@ export const resolvers = {
       authenticate(context.token);
 
       const userRepository = appDataSource.getRepository(User);
-      const fetchedUser: User | undefined = await userRepository.findOne({
+
+      const fetchedUser: User = await userRepository.findOne({
         where: {
           id: +args.data.id,
         },
+        relations: ['addresses'],
       });
 
       if (!fetchedUser) {
@@ -58,21 +60,13 @@ export const resolvers = {
         },
         skip: skippedUsers,
         take: maxUsers,
-      });
-
-      const processedCheckUsers = fetchedUsers.map((user) => {
-        return {
-          birthDate: user.birthDate,
-          email: user.email,
-          id: user.id.toString(),
-          name: user.name,
-        };
+        relations: ['addresses'],
       });
 
       const isLast = maxUsers + skippedUsers >= userCount;
       const isFirst = skippedUsers == 0;
 
-      return { users: processedCheckUsers, userCount: userCount, isLast: isLast, isFirst: isFirst };
+      return { users: fetchedUsers, userCount: userCount, isLast: isLast, isFirst: isFirst };
     },
   },
 

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -118,6 +118,7 @@ export const resolvers = {
         where: {
           email: args.data.email,
         },
+        relations: ['addresses'],
       });
 
       if (users.length == 0) {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -16,14 +16,7 @@ export const typeDefs = `
       neighborhood: String!
       city: String!
       state: String!
-    }
-
-    type SimplifiedUser {
-      id: ID!
-      name: String!
-      email: String!
-      birthDate: String!
-    }
+    }    
 
     type User {
       id: ID!
@@ -40,7 +33,7 @@ export const typeDefs = `
     }
 
     type LoginResponse {
-      user: SimplifiedUser!,            
+      user: User,            
       token: String!
     }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5,23 +5,42 @@ export const typeDefs = `
       hello: String
       user(data: QueryUserInput!): User
       users(data: QueryUsersInput = { skippedUsers: 0, maxUsers: ${MAX_USERS} }): UsersResponse
+    }              
+    
+    type Address {
+      id: ID!
+      cep: String!
+      street: String!
+      streetNumber: String!
+      complement: String
+      neighborhood: String!
+      city: String!
+      state: String!
     }
-      
-    type User {
+
+    type SimplifiedUser {
       id: ID!
       name: String!
       email: String!
       birthDate: String!
     }
+
+    type User {
+      id: ID!
+      name: String!
+      email: String!
+      birthDate: String!
+      addresses: [Address]!
+    }
     type UsersResponse {
-      users: [User]!,
+      users: [User]!
       userCount: Int!
-      isLast: Boolean!,
+      isLast: Boolean!
       isFirst: Boolean!
     }
 
     type LoginResponse {
-      user: User!,            
+      user: SimplifiedUser!,            
       token: String!
     }
 

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -48,10 +48,20 @@ export async function userQueryRequest(variables: { input: QueryUserInput }, tok
     {
       query: `query ($input: QueryUserInput!) {
         user(data: $input) {
+          id
+          name
           email
           birthDate
-          name
-          id
+          addresses {
+            id
+            cep
+            street
+            streetNumber
+            complement
+            neighborhood
+            city
+            state
+          }
         }
       }`,
       variables: variables,
@@ -79,6 +89,16 @@ export async function usersQueryRequest(variables: { input?: QueryUsersInput } |
             name
             email
             birthDate          
+            addresses {
+              id
+              cep
+              street
+              streetNumber
+              complement
+              neighborhood
+              city
+              state
+            }
           }
         }
       }`,

--- a/src/test/login.test.ts
+++ b/src/test/login.test.ts
@@ -6,6 +6,7 @@ import { CustomError } from '../custom-error';
 import { hashPassword } from '../utils';
 import { generateToken } from '../token-generator';
 import { verify } from 'jsonwebtoken';
+import { Address } from '../entity/Address';
 
 async function createUser(user: { name: string; password: string; birthDate: string; email: string }) {
   const userRepository = appDataSource.getRepository(User);
@@ -15,6 +16,7 @@ async function createUser(user: { name: string; password: string; birthDate: str
 
 describe('Login Mutation', () => {
   afterEach(async () => {
+    await appDataSource.createQueryBuilder().delete().from(Address).execute();
     await appDataSource.createQueryBuilder().delete().from(User).execute();
   });
 

--- a/src/test/user-query.test.ts
+++ b/src/test/user-query.test.ts
@@ -90,7 +90,7 @@ describe('User query', () => {
     });
   });
 
-  it("should fetch the requested user and it's addresses.", async () => {
+  it('should fetch the requested user and its addresses.', async () => {
     const userRepository = appDataSource.getRepository(User);
     const addressRepository = appDataSource.getRepository(Address);
     const user = {

--- a/src/test/user-query.test.ts
+++ b/src/test/user-query.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { User } from '../entity/User';
+import { Address } from '../entity/Address';
 import { appDataSource } from '../data-source';
 import { CustomError } from '../custom-error';
 import { userQueryRequest } from './helper';
@@ -7,6 +8,7 @@ import { generateToken } from '../token-generator';
 
 describe('User query', () => {
   afterEach(async () => {
+    await appDataSource.createQueryBuilder().delete().from(Address).execute();
     await appDataSource.createQueryBuilder().delete().from(User).execute();
   });
 
@@ -77,8 +79,74 @@ describe('User query', () => {
     const userId: string = savedUser.id.toString();
     const token = generateToken(process.env.JWT_KEY ?? '', { id: userId }, false);
     const response = await userQueryRequest({ input: { id: userId } }, token);
+    const fetchedUser = response?.data?.data?.user;
 
-    expect(response).to.exist;
+    expect(fetchedUser).to.deep.eq({
+      id: savedUser.id.toString(),
+      name: savedUser.name,
+      birthDate: savedUser.birthDate,
+      email: savedUser.email,
+      addresses: [],
+    });
+  });
+
+  it("should fetch the requested user and it's addresses.", async () => {
+    const userRepository = appDataSource.getRepository(User);
+    const addressRepository = appDataSource.getRepository(Address);
+    const user = {
+      birthDate: '09/11/2022',
+      email: 'test@fake.com',
+      name: 'test user',
+      password: 'c0rr3ctp4ass',
+    };
+    const savedUser: User = await userRepository.save(user);
+    const userId: string = savedUser.id.toString();
+    const address1 = {
+      cep: '37112-589',
+      street: 'Feliciano Rua',
+      streetNumber: '70571',
+      complement: 'Apto. 540',
+      neighborhood: 'Grant County',
+      city: 'Enzo Gabriel do Sul',
+      state: 'AP',
+      user: savedUser,
+    };
+    const address2 = {
+      cep: '40344-200',
+      street: 'Leonardo Alameda',
+      streetNumber: '87491',
+      complement: 'Casa 6',
+      neighborhood: 'Durham',
+      city: 'Raul do Sul',
+      state: 'SE',
+      user: savedUser,
+    };
+    const savedAddress1 = await addressRepository.save(address1);
+    const savedAddress2 = await addressRepository.save(address2);
+
+    const token = generateToken(process.env.JWT_KEY ?? '', { id: userId }, false);
+    const response = await userQueryRequest({ input: { id: userId } }, token);
+    const processedAddress1 = {
+      cep: savedAddress1.cep,
+      city: savedAddress1.city,
+      complement: savedAddress1.complement,
+      id: savedAddress1.id.toString(),
+      neighborhood: savedAddress1.neighborhood,
+      state: savedAddress1.state,
+      street: savedAddress1.street,
+      streetNumber: savedAddress1.streetNumber,
+    };
+
+    const processedAddress2 = {
+      cep: savedAddress2.cep,
+      city: savedAddress2.city,
+      complement: savedAddress2.complement,
+      id: savedAddress2.id.toString(),
+      neighborhood: savedAddress2.neighborhood,
+      state: savedAddress2.state,
+      street: savedAddress2.street,
+      streetNumber: savedAddress2.streetNumber,
+    };
 
     const fetchedUser = response?.data?.data?.user;
 
@@ -87,6 +155,7 @@ describe('User query', () => {
       name: savedUser.name,
       birthDate: savedUser.birthDate,
       email: savedUser.email,
+      addresses: [processedAddress1, processedAddress2],
     });
   });
 });


### PR DESCRIPTION
- Change the return objects of user and users queries to include the addresses;
- Update tests to reflect the new behavior of the queries;
- Update login response type in schema to not include the addresses.